### PR TITLE
FIX: Canonizalize Windows path sep in xolox#misc#path#absolute().

### DIFF
--- a/autoload/xolox/misc/path.vim
+++ b/autoload/xolox/misc/path.vim
@@ -71,7 +71,7 @@ function! xolox#misc#path#absolute(path)
     if exists('stripped_slash') && path !~ '/$'
       let path .= '/'
     endif
-    return path
+    return (s:windows_compatible ? (exists('+shellslash') && ! &shellslash ? substitute(path, '/', '\\', 'g') : substitute(path, '\\', '/', 'g')) : path)
   endif
   return ''
 endfunction


### PR DESCRIPTION
On Windows, just converting to absolute paths is not enough to be able to use string-compare to test for equality. Depending on how it was constructed, the path may contain both forward- and backslashes (even a mix of them!) Therefore, canonicalize to what the 'shellslash' setting is set to.
