### PR TITLE
Handle :normal! fold restore in session file.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -119,9 +119,9 @@ function! xolox#session#save_state(commands) " {{{2
 endfunction
 
 function! s:state_filter(line)
-  if a:line == 'normal zo'
+  if a:line =~ '^normal!\? zo$'
     " Silence "E490: No fold found" errors.
-    return 'silent! normal zo'
+    return 'silent! ' . a:line
   elseif a:line =~ '^file .\{-}\<NERD_tree_\d\+$'
     " Silence "E95: Buffer with this name already exists" when restoring
     " mirrored NERDTree windows.


### PR DESCRIPTION
A recent Vim 7.3 patch fixed the use of `:normal` to `:normal! zo` (so that mappings do not apply). Adapt the plugin's parsing to accommodate this.
