### PR TITLE
Avoid mandatory persistence of Vim size.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -103,7 +103,7 @@ function! xolox#session#save_state(commands) " {{{2
     " which makes them slower to generate and evaluate. It can also be a bit
     " buggy, e.g. it breaks Ctrl-S when :runtime mswin.vim has been used. The
     " value of &sessionoptions is changed temporarily to avoid these issues.
-    set ssop-=options ssop+=resize
+    set ssop-=options
     execute 'mksession' fnameescape(tempfile)
     let lines = readfile(tempfile)
     if lines[-1] == '" vim: set ft=vim :'


### PR DESCRIPTION
This does not affect the plugin's operation; rather, it is the author's preference. Therefore, honor the setting when it's in `'sessionoptions'`, but don't force it.
