### PR TITLE
Fixed SessionLoadPost event being sent at the wrong time

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -287,43 +287,43 @@ function! xolox#session#auto_unlock() " {{{2
   endwhile
 endfunction
 
-function! xolox#session#auto_dirty_check() " {{{2
-  " TODO Why execute this on every buffer change?! Instead execute it only when we want to know whether the session is dirty!
-  " This function is called each time a BufEnter event fires to detect when
-  " the current tab page (or the buffer list) is changed in some way. This
-  " enables the plug-in to not bother with the auto-save dialog when the
-  " session hasn't changed.
-  if v:this_session == ''
-    " Don't waste CPU time when no session is loaded.
-    return
-  elseif !exists('s:cached_layouts')
-    let s:cached_layouts = {}
-  else
-    " Clear non-existing tab pages from s:cached_layouts.
-    let last_tabpage = tabpagenr('$')
-    call filter(s:cached_layouts, 'v:key <= last_tabpage')
-  endif
-  " Check the buffer list.
-  let all_buffers = s:serialize_buffer_list()
-  if all_buffers != get(s:cached_layouts, 0, '')
-    let s:session_is_dirty = 1
-  endif
-  let s:cached_layouts[0] = all_buffers
-  " Check the layout of the current tab page.
-  let tabpagenr = tabpagenr()
-  let keys = ['tabpage:' . tabpagenr]
-  let buflist = tabpagebuflist()
-  for winnr in range(1, winnr('$'))
-    " Create a string that describes the state of the window {winnr}.
-    call add(keys, printf('width:%i,height:%i,buffer:%i',
-          \ winwidth(winnr), winheight(winnr), buflist[winnr - 1]))
-  endfor
-  let layout = join(keys, "\n")
-  if layout != get(s:cached_layouts, tabpagenr, '')
-    let s:session_is_dirty = 1
-  endif
-  let s:cached_layouts[tabpagenr] = layout
-endfunction
+"function! xolox#session#auto_dirty_check() " {{{2
+  "" TODO Why execute this on every buffer change?! Instead execute it only when we want to know whether the session is dirty!
+  "" This function is called each time a BufEnter event fires to detect when
+  "" the current tab page (or the buffer list) is changed in some way. This
+  "" enables the plug-in to not bother with the auto-save dialog when the
+  "" session hasn't changed.
+  "if v:this_session == ''
+    "" Don't waste CPU time when no session is loaded.
+    "return
+  "elseif !exists('s:cached_layouts')
+    "let s:cached_layouts = {}
+  "else
+    "" Clear non-existing tab pages from s:cached_layouts.
+    "let last_tabpage = tabpagenr('$')
+    "call filter(s:cached_layouts, 'v:key <= last_tabpage')
+  "endif
+  "" Check the buffer list.
+  "let all_buffers = s:serialize_buffer_list()
+  "if all_buffers != get(s:cached_layouts, 0, '')
+    "let s:session_is_dirty = 1
+  "endif
+  "let s:cached_layouts[0] = all_buffers
+  "" Check the layout of the current tab page.
+  "let tabpagenr = tabpagenr()
+  "let keys = ['tabpage:' . tabpagenr]
+  "let buflist = tabpagebuflist()
+  "for winnr in range(1, winnr('$'))
+    "" Create a string that describes the state of the window {winnr}.
+    "call add(keys, printf('width:%i,height:%i,buffer:%i',
+          "\ winwidth(winnr), winheight(winnr), buflist[winnr - 1]))
+  "endfor
+  "let layout = join(keys, "\n")
+  "if layout != get(s:cached_layouts, tabpagenr, '')
+    "let s:session_is_dirty = 1
+  "endif
+  "let s:cached_layouts[tabpagenr] = layout
+"endfunction
 
 function! s:serialize_buffer_list()
   if &sessionoptions =~ '\<buffers\>'
@@ -375,7 +375,7 @@ function! xolox#session#open_cmd(name, bang) abort " {{{2
       let s:oldcwd = oldcwd
       call s:lock_session(path)
       execute 'source' fnameescape(path)
-      unlet! s:session_is_dirty
+      let s:session_is_dirty=1
       call s:last_session_persist(name)
       call xolox#misc#timer#stop("session.vim %s: Opened %s session in %s.", g:xolox#session#version, string(name), starttime)
       call xolox#misc#msg#info("session.vim %s: Opened %s session from %s.", g:xolox#session#version, string(name), fnamemodify(path, ':~'))
@@ -417,7 +417,7 @@ function! xolox#session#save_cmd(name, bang) abort " {{{2
       call xolox#misc#msg#info("session.vim %s: Saved %s session to %s.", g:xolox#session#version, string(name), friendly_path)
       let v:this_session = path
       call s:lock_session(path)
-      unlet! s:session_is_dirty
+      "unlet! s:session_is_dirty
     endif
   endif
 endfunction

--- a/plugin/session.vim
+++ b/plugin/session.vim
@@ -79,7 +79,7 @@ augroup PluginSession
   au VimEnter * nested call xolox#session#auto_load()
   au VimLeavePre * call xolox#session#auto_save()
   au VimLeavePre * call xolox#session#auto_unlock()
-  au BufEnter * call xolox#session#auto_dirty_check()
+  "au BufEnter * call xolox#session#auto_dirty_check()
 augroup END
 
 " Define commands that enable users to manage multiple named sessions.


### PR DESCRIPTION
Greetings,

I noticed that in your plugin, the SessionLoadPost event was getting sent at the wrong time. The :mksession file's doautoall was left in place, but more commands were being appended onto the file, namely, initializing NERDTree.

I changed it so that the doautoall at the end of the :mksession file is removed, then a new one is appended onto the end of the final session file.
