### PR TITLE
Allow to forget a saved default session, too.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -327,10 +327,7 @@ function! xolox#session#auto_load() " {{{2
             \ is_default_session ? 'default' : 'last used',
             \ is_default_session ? '' : printf(' (%s)', session))
       " Prepare the list of choices.
-      let choices = ['&Yes', '&No']
-      if !is_default_session
-        call add(choices, '&Forget')
-      endif
+      let choices = ['&Yes', '&No', '&Forget']
       " Prompt the user (if not configured otherwise).
       let choice = s:prompt(msg, choices, 'g:session_autoload')
       if choice == 1


### PR DESCRIPTION
Shutting off the query for auto-loading of a previous session is just as important for the default session, not just custom sessions. This was also the behavior of my original pull request; I don't know why you left that part out.
