### PR TITLE
Remove the -count=94919 workaround for :AppendTabSession.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -729,7 +729,7 @@ endfunction
 function! xolox#session#append_tab_cmd(name, bang, count, command) abort " {{{2
   try
     call xolox#session#change_tab_options()
-    execute printf('%stabnew', a:count == 94919 ? '' : a:count)
+    execute printf('%stabnew', a:count == -1 ? '' : a:count)
     call xolox#session#open_cmd(a:name, a:bang, a:command)
   finally
     call xolox#session#restore_tab_options()

--- a/plugin/session.vim
+++ b/plugin/session.vim
@@ -165,7 +165,7 @@ command! -bar -bang CloseSession call xolox#session#close_cmd(<q-bang>, 0, 1, 'C
 " sessions (used to persist/restore the window layout of a single tab page).
 command! -bar -bang -nargs=? -complete=customlist,xolox#session#complete_names OpenTabSession call xolox#session#open_tab_cmd(<q-args>, <q-bang>, 'OpenTabSession')
 command! -bar -bang -nargs=? -complete=customlist,xolox#session#complete_names SaveTabSession call xolox#session#save_tab_cmd(<q-args>, <q-bang>, 'SaveTabSession')
-command! -bar -bang -count=94919 -nargs=? -complete=customlist,xolox#session#complete_names AppendTabSession call xolox#session#append_tab_cmd(<q-args>, <q-bang>, <count>, 'AppendTabSession')
+command! -bar -bang -range=-1 -nargs=? -complete=customlist,xolox#session#complete_names AppendTabSession call xolox#session#append_tab_cmd(<q-args>, <q-bang>, <count>, 'AppendTabSession')
 command! -bar -bang CloseTabSession call xolox#session#close_tab_cmd(<q-bang>, 'CloseTabSession')
 
 " Define a command to restart Vim editing sessions.
@@ -183,7 +183,7 @@ if g:session_command_aliases
   command! -bar -bang SessionClose call xolox#session#close_cmd(<q-bang>, 0, 1, 'SessionClose')
   command! -bar -bang -nargs=? -complete=customlist,xolox#session#complete_names SessionTabOpen call xolox#session#open_tab_cmd(<q-args>, <q-bang>, 'SessionTabOpen')
   command! -bar -bang -nargs=? -complete=customlist,xolox#session#complete_names SessionTabSave call xolox#session#save_tab_cmd(<q-args>, <q-bang>, 'SessionTabSave')
-  command! -bar -bang -count=94919 -nargs=? -complete=customlist,xolox#session#complete_names SessionTabAppend call xolox#session#append_tab_cmd(<q-args>, <q-bang>, <count>, 'SessionTabAppend')
+  command! -bar -bang -range=-1 -nargs=? -complete=customlist,xolox#session#complete_names SessionTabAppend call xolox#session#append_tab_cmd(<q-args>, <q-bang>, <count>, 'SessionTabAppend')
   command! -bar -bang SessionTabClose call xolox#session#close_tab_cmd(<q-bang>, 'SessionTabClose')
 endif
 


### PR DESCRIPTION
As the command only takes the optional count _before_ the command (like :tabnew, as per the documentation), no count can be detected by -1 if we specify -range=-1.
This also avoids the unexpected behavior of -count that a passed argument in the form "42foo" is parsed as count=42 and args=foo. With this change, one can properly define session names that start with numbers.
