### PR TITLE
Save "laststatus" and "linespace" to provide visual consistency across editing environments

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -41,6 +41,9 @@ function! xolox#session#save_session(commands, filename) " {{{2
   if has('gui') && is_all_tabs
     call add(a:commands, 'set guioptions=' . escape(&go, ' "\'))
     call add(a:commands, 'silent! set guifont=' . escape(&gfn, ' "\'))
+    call add(a:commands, 'set linespace=' . &linespace)
+    " Changing the linespace sometimes leaves the screen messed up.
+    call add(a:commands, 'redraw')
   endif
   call xolox#session#save_globals(a:commands)
   if is_all_tabs
@@ -51,6 +54,7 @@ function! xolox#session#save_session(commands, filename) " {{{2
   call xolox#session#save_state(a:commands)
   if is_all_tabs
     call xolox#session#save_fullscreen(a:commands)
+    call add(a:commands, 'set laststatus=' . &laststatus)
   endif
   if is_all_tabs
     call add(a:commands, 'doautoall SessionLoadPost')


### PR DESCRIPTION
I use different fonts for editing code and editing long markdown documents. These fonts require a bit of tweaking with regard to the linespace. I also turn off the status bar to allow for a more "minimalist" editing environment (usually fullscreen). Adding these changes does the trick for me. They have few side-effects (they're purely visual) so maybe others might find them useful.
