### PR TITLE
FIX: Correct order of tab and window restore commands.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -356,10 +356,10 @@ function! s:check_special_window(session)
 endfunction
 
 function! s:jump_to_window(session, tabpage, window)
+  call add(a:session, a:window . 'wincmd w')
   if xolox#session#include_tabs()
     call add(a:session, 'tabnext ' . a:tabpage)
   endif
-  call add(a:session, a:window . 'wincmd w')
 endfunction
 
 function! s:nerdtree_persist()


### PR DESCRIPTION
The tabpage and window arguments given to s:jump_to_window() refer to the current values, so when inserting into the session file, first the tabpage, then the window (in that tabpage) have to be restored.
