### PR TITLE
Write correct session lock when (auto-)opening tab-scoped session.

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -560,6 +560,7 @@ function! xolox#session#open_cmd(name, bang, command) abort " {{{2
       call s:lock_session(path)
       execute 'source' fnameescape(path)
       if xolox#session#is_tab_scoped()
+        call s:lock_session(path) " Retroactively (this is only known after the session has been loaded) add the tabpage to the lock.
         let t:session_old_cwd = oldcwd
         let session_type = 'tab scoped'
       else
@@ -1022,7 +1023,7 @@ function! s:vim_instance_id()
   if !empty(v:servername)
     let id['servername'] = v:servername
   endif
-  if !xolox#session#include_tabs()
+  if !xolox#session#include_tabs() || xolox#session#is_tab_scoped()
     let id['tabpage'] = tabpagenr()
   endif
   return id


### PR DESCRIPTION
When a tab-scoped session is automatically opened during load (or via the :OpenSession command), the session lock does not contain the 'tabpage' attribute. This causes the auto-save when quitting Vim to fail with "The 'default' session is already loaded in this Vim. Use the command ':SaveTabSession! default' to override."

During auto-load (because we cannot know whether the to-be-loaded session is a session-scoped one), we need to update the lock in case of a tab-scoped session _after_ opening the session.
Additionally, the s:vim_instance_id() function also needs to consider xolox#session#is_tab_scoped(), as only that is set during (auto-)load; xolox#session#include_tabs() only gives the correct result when one of the :...TabSession commands is invoked.
