### PR TITLE
Make GUI dialogs from s:prompt easier to read

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -409,7 +409,7 @@ function! xolox#session#auto_load() " {{{2
             \ is_default_session ? 'default' : 'last used',
             \ is_default_session ? '' : printf(' (%s)', session))
       " Prepare the list of choices.
-      let choices = ['&Yes', '&No']
+      let choices = ['&Restore', '&Don’t Restore']
       if g:session_default_to_last && has_last_session
         call add(choices, '&Forget')
       endif
@@ -448,7 +448,7 @@ function! xolox#session#auto_save() " {{{2
   if !empty(name)
     let is_tab_scoped = xolox#session#is_tab_scoped()
     let msg = "Do you want to save your %s before quitting Vim?"
-    if s:prompt(printf(msg, xolox#session#get_label(name, is_tab_scoped)), ['&Yes', '&No'], 'g:session_autosave') == 1
+    if s:prompt(printf(msg, xolox#session#get_label(name, is_tab_scoped)), ['&Save', '&Don’t Save'], 'g:session_autosave') == 1
       if g:session_default_overwrite && (name == g:session_default_name)
         let bang = '!'
       else
@@ -520,7 +520,7 @@ function! s:prompt(msg, choices, option_name)
     return 0
   else
     if g:session_verbose_messages
-      let format = "%s Note that you can permanently disable this dialog by adding the following line to your %s script:\n\n\t:let %s = 'no'"
+      let format = "%s\n\nNote that you can permanently disable this dialog by adding the following line to your %s script:\n\n\t:let %s = 'no'"
       let prompt = printf(format, a:msg, xolox#misc#os#is_win() ? '~\_vimrc' : '~/.vimrc', a:option_name)
     else
       let prompt = a:msg
@@ -657,7 +657,7 @@ function! xolox#session#close_cmd(bang, silent, save_allowed, command) abort " {
     if a:save_allowed
       let msg = "Do you want to save your current %s before closing it?"
       let label = xolox#session#get_label(name, !is_all_tabs)
-      if s:prompt(printf(msg, label), ['&Yes', '&No'], 'g:session_autosave') == 1
+      if s:prompt(printf(msg, label), ['&Save', '&Don’t Save'], 'g:session_autosave') == 1
         call xolox#session#save_cmd(name, a:bang, a:command)
       endif
     else


### PR DESCRIPTION
A combination of two changes:

- Add blank lines between the actual message and the note about how to disable the dialog. This makes it easier to read the important part of the dialog and ignore the note, if you have already decided that you don’t want to add that line to your vimrc.
 
  It makes an especially big improvement in MacVim, which follows Mac OS X’s convention displaying the first paragraph of a dialog in larger, bold text.

- Replace generic Yes and No button labels with ones specific to the dialog. It is a standard best practice to use buttons that describe the actual action when possible, instead of generic Yes/No buttons – see [User Experience Stack Exchange “Should I use Yes/No or Ok/Cancel on my message box?”](http://ux.stackexchange.com/q/9946/16961) for details.

  Thankfully, `s:prompt` was already written such that the labels can be changed without having to change any other code.

Before:

![a “restore your default editing session” dialog before my changes](https://cloud.githubusercontent.com/assets/79168/4622904/c53d20ac-5342-11e4-8442-8d8bf84eeb93.png)

After:

![a “restore your default editing session” dialog after my changes](https://cloud.githubusercontent.com/assets/79168/4622906/cb2ab8bc-5342-11e4-9c80-98fcf4010d10.png)
