### PR TITLE
Implement custom filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,32 @@ list with one string on success and an empty list on failure.
 
 <!-- End of generated documentation -->
 
+### Using a custom filter on save
+
+#### The `xolox#session#use_custom_filter()` function
+
+You can use this function to provide a `funcref` to filter the commands through
+before `vim-session` saves them. This allows for raw modification of the actual 
+session file contents, so use with care. In this example we persist the tab names
+previously assigned with [gcmt/taboo.vim](https://github.com/gcmt/taboo.vim):
+
+```
+function! CustomFilter(commands)
+  let currentTab = tabpagenr()
+  let tabNames = []
+  tabdo call add(tabNames, TabooTabName(tabpagenr()))
+  exec 'tabn ' . currentTab
+  let idx = match(a:commands, '^[^"]') - 1
+  for t in tabNames
+    if !empty(t)
+      call insert(a:commands, 'TabooRename ' . t, idx+1)
+    endif
+    let idx = match(a:commands, '^tabedit', idx+2)
+  endfor
+endfunction
+call xolox#session#use_custom_filter(function('CustomFilter'))
+```
+
 ## Troubleshooting
 
 ### Using multiple platforms (multi boot, Cygwin, etc.)

--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -8,6 +8,14 @@ let g:xolox#session#version = '2.13.1'
 
 " Public API for session persistence. {{{1
 
+function! xolox#session#use_custom_filter(fn)
+  if type(a:fn) == 2
+    let s:custom_filter = a:fn
+  elseif exists('s:custom_filter')
+    unlet s:custom_filter
+  endif
+endfunction
+
 function! xolox#session#save_session(commands, filename) " {{{2
   " Save the current Vim editing session to a Vim script using the
   " [:mksession] [] command and some additional Vim magic provided by the
@@ -197,6 +205,9 @@ function! xolox#session#save_state(commands) " {{{2
     call s:cleanup_after_plugin(a:commands, 's:wipebuf')
     call add(a:commands, "  endif")
     call add(a:commands, "endif")
+    if exists('s:custom_filter') && type(s:custom_filter) == 2
+      call s:custom_filter(a:commands)
+    endif
     return 1
   finally
     let &sessionoptions = ssop_save


### PR DESCRIPTION
Introducing `use_custom_filter` API to allow ad-hoc output modification from one's vimrc.