### PR TITLE
Do not clobber v:this_session during session save

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -175,7 +175,9 @@ function! xolox#session#save_state(commands) " {{{2
     " buggy, e.g. it breaks Ctrl-S when :runtime mswin.vim has been used. The
     " value of &sessionoptions is changed temporarily to avoid these issues.
     set ssop-=options
+    let session_save = v:this_session
     execute 'mksession' fnameescape(tempfile)
+    let v:this_session = session_save
     let lines = readfile(tempfile)
     " Remove the mode line added by :mksession because we'll add our own in
     " xolox#session#save_session().


### PR DESCRIPTION
_Hello Peter, haven't heard from each other in quite a while. I've been using your plugin(s) happily :-) I hope you're well and you still maintain your plugins, because here's a tiny fix:_

When saving a session, the plugin uses `:mksession` with a temp file, whose name is generated via `tempname()`. If no session so far existed, Vim will derive a session name (and put this into `v:this_session`) from that temp file name, e.g. `/tmp/v3CCl7f/20` will turn into `v:this_session = "20"`. Now, when another (unnamed) session is saved, the plugin will pick up `v:this_session` and use `"20"` instead of `"default"`, which is irritating and unexpected.
Easy fix: Save and restore the value of `v:this_session`.
