### PR TITLE
force recreation of directory containing temporary file

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -167,6 +167,11 @@ function! xolox#session#save_state(commands) " {{{2
   " script.
   let tempfile = tempname()
   let ssop_save = &sessionoptions
+
+  try
+    call mkdir(fnamemodify(tempname(), ":p:h"), "", 0700)
+  catch
+  endtry
   try
     " The default value of &sessionoptions includes "options" which causes
     " :mksession to include all Vim options and mappings in generated session


### PR DESCRIPTION
Apparently, Vim's tempname() function upon first invocation creates a temporary
directory along with a temporary file below it. Subsequent invocations assume
the temporary directory to be still existent. If that is not the case,
attempting to access to temporary file will fail.
In many cases we have seen errors popping up because this temporary directory
was removed and no attempt to recreate it was made by Vim. For lack of a better
solution and my unfamiliarity with Vim script (paired with an aversion towards
it), this change simply forcefully attempts to recreate the directory and
ignores any errors doing so.