### PR TITLE
I had to [Enter] to conitunue from autoload

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -184,7 +184,7 @@ function! xolox#session#save_state(commands) " {{{2
     " output. We will fire the event ourselves when we're really done.
     call s:eat_trailing_line(lines, 'unlet SessionLoad')
     call s:eat_trailing_line(lines, 'doautoall SessionLoadPost')
-    if g:session_ignore_special_pages != 'yes'
+    if exists("g:session_ignore_special_pages")
       call xolox#session#save_special_windows(lines)
     endif
     if !xolox#session#include_tabs()

--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -235,6 +235,7 @@ endfunction
 
 function! s:state_filter(line) " {{{3
   " Various changes to the output of :mksession.
+  " echom "a:line=" . a:line
   if a:line =~ '^normal!\? zo$'
     " Silence "E490: No fold found" errors.
     return 'silent! ' . a:line
@@ -244,6 +245,10 @@ function! s:state_filter(line) " {{{3
     return '" ' . a:line
   elseif a:line =~ '^file .\{-}\[BufExplorer\]$'
     " Same trick (about the E95) for BufExplorer.
+    return '" ' . a:line
+  " elseif a:line =~ '^file -MiniBufExplorer-$'
+  "   return '" ' . a:line
+  elseif a:line =~ '^file .\{-}__Tagbar__$'
     return '" ' . a:line
   elseif a:line =~ '^file .\{-}__Tag_List__$'
     " Same trick (about the E95) for TagList.
@@ -311,8 +316,14 @@ function! s:check_special_window(session)
       let command = 'NERDTreeMirror'
       let argument = ''
     endif
+  " elseif bufname == '-MiniBufExplorer-'
+  "   let command = 'MBEOpen'
+  "   let argument = ''
   elseif bufname == '[BufExplorer]'
     let command = 'BufExplorer'
+    let argument = ''
+  elseif bufname == '__Tagbar__'
+    let command = 'TagbarOpen'
     let argument = ''
   elseif bufname == '__Tag_List__'
     let command = 'Tlist'

--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -184,7 +184,9 @@ function! xolox#session#save_state(commands) " {{{2
     " output. We will fire the event ourselves when we're really done.
     call s:eat_trailing_line(lines, 'unlet SessionLoad')
     call s:eat_trailing_line(lines, 'doautoall SessionLoadPost')
-    call xolox#session#save_special_windows(lines)
+    if g:session_ignore_special_pages != 'yes'
+      call xolox#session#save_special_windows(lines)
+    endif
     if !xolox#session#include_tabs()
       " Customize the output of :mksession for tab scoped sessions.
       let buffers = tabpagebuflist()

--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -590,7 +590,10 @@ function! xolox#session#open_cmd(name, bang, command) abort " {{{2
       call s:last_session_persist(name)
       call s:flush_session()
       call xolox#misc#timer#stop("session.vim %s: Opened %s %s session in %s.", g:xolox#session#version, session_type, string(name), starttime)
-      call xolox#misc#msg#info("session.vim %s: Opened %s %s session from %s.", g:xolox#session#version, session_type, string(name), fnamemodify(path, ':~'))
+      if g:session_verbose_messages
+      " this may force user to press [Enter]
+        call xolox#misc#msg#info("session.vim %s: Opened %s %s session from %s.", g:xolox#session#version, session_type, string(name), fnamemodify(path, ':~'))
+      endif
     endif
   endif
   return 1


### PR DESCRIPTION
Maybe because the session opened message is too long, it interrupts the startup.
Use g:session_verbose_messages to oppress it.